### PR TITLE
Bug fixed ZK-2158: Tab can be click on blank area next to last tab (IE9 ...

### DIFF
--- a/src/main/resources/web/atlantic/js/zul/tab/less/tabbox.less
+++ b/src/main/resources/web/atlantic/js/zul/tab/less/tabbox.less
@@ -384,3 +384,12 @@
 		min-height: @headerHeight - @paddingSize * 2;
 	}
 }
+
+// ZK-2158: Tab should not be click on blank area next to last tab
+.ie9 .z-tabs {
+    line-height: 1px;
+
+    > .z-tabs-content {
+	    display: inline-block;
+	}
+}


### PR DESCRIPTION
...only)

http://tracker.zkoss.org/browse/ZK-2158
