### PR TITLE
refine ZK-4760: default error message box hard coded width (too small)

### DIFF
--- a/src/archive/web/js/zul/wnd/less/window.less
+++ b/src/archive/web/js/zul/wnd/less/window.less
@@ -94,6 +94,9 @@
 
 	&-window .z-window-content {
 		padding: 16px 0px;
+		> .z-separator {
+			height: 16px !important;
+		}
 	}
 
 	&-window {
@@ -139,6 +142,6 @@
 	&-viewport {
 		overflow: auto;
 		white-space: nowrap;
-		margin-bottom: 16px;
+		width: 430px;
 	}
 }


### PR DESCRIPTION
refine ZK-4760: default error message box hard coded width (too small)