### PR TITLE
ZK-4760: default error message box hard coded width (too small)

### DIFF
--- a/src/archive/web/js/zul/wnd/less/window.less
+++ b/src/archive/web/js/zul/wnd/less/window.less
@@ -91,6 +91,12 @@
 	&-window .z-window-content {
 		padding: @paddingLarge;
 	}
+
+	&-window {
+		min-width: 250px;
+		max-width: 50%;
+	}
+
 	.z-label {
 		.fontStyle(@contentFontFamily, @baseFontSize, @baseFontWeight, @baseTextColor);
 	}

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -9,6 +9,7 @@ Atlantic 9.5.1
   ZK-4684: menuitem icon alignment
   ZK-4724: combowidget button icon alignment
   ZK-4733: a scroll thumb keeps moving itself during scrolling
+  ZK-4760: default error message box hard coded width (too small)
 
 * Upgrade Notes:
 


### PR DESCRIPTION
ZK-4760: default error message box hard coded width (too small)