### PR TITLE
Revert ZK-4760: default error message box hard coded width (too small)

### DIFF
--- a/src/archive/web/js/zul/wnd/less/window.less
+++ b/src/archive/web/js/zul/wnd/less/window.less
@@ -88,27 +88,17 @@
 }
 
 .z-messagebox {
-	display: inline-block;
-	white-space: normal;
-	padding: 0px 16px 16px;
-
 	&-window .z-window-content {
-		padding: 16px 0px;
+		padding: @paddingLarge;
 	}
-
-	&-window {
-		width: 440px;
-	}
-
 	.z-label {
 		.fontStyle(@contentFontFamily, @baseFontSize, @baseFontWeight, @baseTextColor);
 	}
 
 	&-buttons {
-		text-align: right;
-		margin-right: 16px;
+		text-align: center;
 		& > * {
-			margin: 0 4px;
+			margin: 0 2px;
 		}
 	}
 
@@ -119,9 +109,6 @@
 	&-icon {
 		.size(32px, 32px);
 		background-repeat: no-repeat;
-		margin-left: 16px;
-		display: inline-block;
-		vertical-align: top;
 	}
 	&-question {
 		.encodeThemeURL(background-image, '~./zul/img/msgbox/question-btn.png');
@@ -134,11 +121,5 @@
 	}
 	&-error {
 		.encodeThemeURL(background-image, '~./zul/img/msgbox/stop-btn.png');
-	}
-
-	&-viewport {
-		overflow: auto;
-		white-space: nowrap;
-		margin-bottom: 16px;
 	}
 }

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -9,7 +9,6 @@ Atlantic 9.5.1
   ZK-4684: menuitem icon alignment
   ZK-4724: combowidget button icon alignment
   ZK-4733: a scroll thumb keeps moving itself during scrolling
-  ZK-4760: default error message box hard coded width (too small)
 
 * Upgrade Notes:
 


### PR DESCRIPTION
This reverts commit 41aeb9ff009305efbbfcce8bfc4891b33a90cd2a.