### PR TITLE
ZK-4665: Using percent width in columnlayout cause line break in fire…

### DIFF
--- a/src/archive/web/js/zkex/layout/less/columnlayout.less
+++ b/src/archive/web/js/zkex/layout/less/columnlayout.less
@@ -1,5 +1,9 @@
 @import "~./zul/less/_header.less";
 
+.z-columnlayout {
+	white-space: nowrap;
+}
+
 .z-columnlayout,
 .z-columnchildren,
 .z-columnchildren-content {
@@ -7,7 +11,9 @@
 }
 .z-columnchildren {
 	height: 100%;
-	float: left;
+	display: inline-block;
+	vertical-align: top;
+
 	&-content {
 		height: 100%;
 		width: 100%;

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -10,6 +10,7 @@ Atlantic 9.5.1
   ZK-4724: combowidget button icon alignment
   ZK-4733: a scroll thumb keeps moving itself during scrolling
   ZK-4760: default error message box hard coded width (too small)
+  ZK-4665: Using percent width in columnlayout cause line break in firefox and edge
 
 * Upgrade Notes:
 


### PR DESCRIPTION
…fox and edge