### PR TITLE
refine ZK-4760: default error message box hard coded width (too small)

### DIFF
--- a/src/archive/web/js/zul/wnd/less/window.less
+++ b/src/archive/web/js/zul/wnd/less/window.less
@@ -90,11 +90,7 @@
 .z-messagebox {
 	&-window .z-window-content {
 		padding: @paddingLarge;
-	}
-
-	&-window {
-		min-width: 250px;
-		max-width: 100vw;
+		overflow: auto;
 	}
 
 	.z-label {
@@ -103,6 +99,8 @@
 
 	&-buttons {
 		text-align: center;
+		left: 0;
+		position: sticky;
 		& > * {
 			margin: 0 2px;
 		}


### PR DESCRIPTION
refine ZK-4760: default error message box hard coded width (too small)