### PR TITLE
ZK-4600: readonly spinner buttons should not be clickable

### DIFF
--- a/src/archive/web/js/zul/inp/less/combo.less
+++ b/src/archive/web/js/zul/inp/less/combo.less
@@ -79,13 +79,18 @@
 		text-align: center;
 	}
 
-	&-disabled {
+	&-disabled, &-readonly {
 		.opacity(@disabledOpacity);
 		& * {
-			color: @inputDisabledColor !important;
 			background: @inputDisabledBackground !important;
 			cursor: default !important;
 		}
+	}
+	&-disabled > input {
+		color: @inputDisabledColor;
+	}
+	&-readonly > &-input&-focus, &-readonly > &-focus + &-button {
+		border-color: @readonlyBorderColor;
 	}
 
 	&-invalid {
@@ -170,7 +175,10 @@
 
 .z-timebox-disabled a,
 .z-spinner-disabled a,
-.z-doublespinner-disabled a {
+.z-doublespinner-disabled a,
+.z-timebox-readonly a,
+.z-spinner-readonly a,
+.z-doublespinner-readonly a {
 	&:hover {
 		background: 0;
 	}

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -4,6 +4,7 @@ Atlantic 9.6.0
   ZK-4795: Grid/Listbox/Tree supports sticky column headers
 
 * Bugs:
+  ZK-4600: readonly spinner buttons should not be clickable
 
 * Upgrade Notes:
 


### PR DESCRIPTION
ZK-4600: readonly spinner buttons should not be clickable