### PR TITLE
ZK-4858: slider knob styles contain invalid css property

### DIFF
--- a/src/archive/web/js/zul/inp/less/slider.less
+++ b/src/archive/web/js/zul/inp/less/slider.less
@@ -20,12 +20,10 @@
 
 	&-knob-area {
 		stroke: @sliderAreaBackgroundColor;
-		data-angleOffset: 0;
 	}
 
 	&-knob-inner {
 		stroke: @sliderBackgroundColor;
-		data-angleOffset: 0;
 	}
 
 	&-knob-svg {

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -7,6 +7,7 @@ Atlantic 9.6.0
   ZK-4771: Provide a way to add theme-uri without extends any existing ThemeProvider
   ZK-2299: Frozen column support on tablet device
   ZK-4844: Replace spacer.gif by a base64 encoded string
+  ZK-4858: slider knob styles contain invalid css property
 
 * Bugs:
   ZK-4801: Atlantic: adds google-font for all themes


### PR DESCRIPTION
ZK-4858: slider knob styles contain invalid css property