### PR TITLE
ZK-5120: Combobox smart update emptySearchMessage doesn't work

### DIFF
--- a/src/main/resources/web/atlantic/js/zul/inp/less/combo.less
+++ b/src/main/resources/web/atlantic/js/zul/inp/less/combo.less
@@ -219,7 +219,7 @@
 }
 
 // combobox emptySearchMessage
-.z-combobox-emptySearchMessage {
+.z-combobox-empty-search-message {
 	display: block;
 	padding: @paddingSmall @paddingSize;
 	line-height: @buttonHeight - @paddingSmall * 2;
@@ -229,7 +229,7 @@
 	min-height: @buttonHeight - @paddingSmall * 2;
 	color: @disabledColor;
 }
-.z-combobox-emptySearchMessage-hidden {
+.z-combobox-empty-search-message-hidden {
 	display: none;
 }
 

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -13,6 +13,9 @@ Atlantic 10.0.0
   ZK-5055: atlantic borderlayout east/west always rotated by 90deg (since 9.6.0)
 
 * Upgrade Notes:
+  + Some z-class names are changed:
+        z-combobox-emptySearchMessage -> z-combobox-empty-search-message
+        z-combobox-emptySearchMessage-hidden -> z-combobox-empty-search-message-hidden
 
   --------
 Atlantic 9.6.0


### PR DESCRIPTION
ZK-5120: Combobox smart update emptySearchMessage doesn't work